### PR TITLE
feature: Zeplinko#44 | Retryable api migration to Bi-Predicate

### DIFF
--- a/src/main/java/org/zeplinko/commons/lang/ext/util/Retryable.java
+++ b/src/main/java/org/zeplinko/commons/lang/ext/util/Retryable.java
@@ -2,14 +2,14 @@ package org.zeplinko.commons.lang.ext.util;
 
 import jakarta.annotation.Nonnull;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.zeplinko.commons.lang.ext.annotations.Preview;
+import org.zeplinko.commons.lang.ext.core.AbstractOutcome;
 import org.zeplinko.commons.lang.ext.core.Result;
 
 import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
+import java.util.function.BiPredicate;
 
 import static org.zeplinko.commons.lang.ext.util.Retryable.Outcome.TerminationReason.*;
 
@@ -21,21 +21,23 @@ import static org.zeplinko.commons.lang.ext.util.Retryable.Outcome.TerminationRe
  * using:
  * </p>
  * <ul>
- * <li>{@link #retryUntilResult(Predicate)} – validation predicate that must
- * hold for the <em>result</em> to be accepted</li>
- * <li>{@link #retryOnFailure(Predicate)} – declare <em>exceptions</em> that
- * trigger a retry</li>
- * <li>{@link #noRetryOnFailure(Predicate)} – declare <em>exceptions</em> that
- * should not trigger a retry</li>
+ * <li>{@link #retryUntilResult(BiPredicate)} – validation bi-predicate that
+ * must hold for the <em>result</em> and <em>attempt number</em> to be
+ * accepted</li>
+ * <li>{@link #retryOnFailure(BiPredicate)} – declare <em>exceptions</em> and
+ * <em>attempt numbers</em> that trigger a retry</li>
+ * <li>{@link #noRetryOnFailure(BiPredicate)} – declare <em>exceptions</em> and
+ * <em>attempt numbers</em> that should not trigger a retry</li>
  * <li>{@link #maxRetries(int)} – maximum retry attempts</li>
  * <li>{@link #baseDelay(long, TimeUnit)} – base delay between attempts</li>
  * <li>{@link #backoff(BackoffStrategy)} – back-off strategy for calculating the
  * next delay</li>
  * </ul>
- * The task is started by calling {@link #run()} which returns a {@link Outcome}
- * describing the outcome. Since {@code Retryable} implements {@link Callable},
- * it can also be used directly with
- * {@link java.util.concurrent.ExecutorService} and other concurrency utilities.
+ * The task is started by calling {@link #run()} which returns an
+ * {@link Outcome} extending {@link AbstractOutcome} describing the outcome.
+ * Since {@code Retryable} implements {@link Callable}, it can also be used
+ * directly with {@link java.util.concurrent.ExecutorService} and other
+ * concurrency utilities.
  * <p>
  * <strong>Thread-safety:</strong> Instances of {@code Retryable} are
  * <em>not</em> designed for concurrent use. Configure the instance in a single
@@ -44,21 +46,22 @@ import static org.zeplinko.commons.lang.ext.util.Retryable.Outcome.TerminationRe
  * {@code Retryable} per thread.
  * </p>
  *
- * @author A&nbsp;Anand
- *
  * @param <R> the type of the successful result returned by the task
+ * @author A&nbsp;Anand
  */
 @Preview
 public final class Retryable<R> implements Callable<Retryable.Outcome<R>> {
 
     private final Callable<R> retryableTask;
 
-    private Predicate<? super R> resultPredicate = r -> true; // Validation predicate: accept any result by default
+    // Validation predicate:accept any result by default
+    private BiPredicate<? super R, Integer> resultPredicate = (result, currentAttempt) -> true;
 
-    private Predicate<? super Exception> exceptionPredicate = e -> false; // Do not retry on exceptions by default
+    // Do not retry on exceptions by default
+    private BiPredicate<? super Exception, Integer> exceptionPredicate = (exception, currentAttempt) -> false;
 
-    private Predicate<? super Exception> noRetryOnFailure = e -> false; // By default, there is no no-retry
-                                                                        // exceptions
+    // By default, there are no no-retry exceptions
+    private BiPredicate<? super Exception, Integer> noRetryOnFailure = (exception, currentAttempt) -> false;
 
     private int maxRetries = 0;
 
@@ -76,65 +79,74 @@ public final class Retryable<R> implements Callable<Retryable.Outcome<R>> {
      * @param task the {@link Callable} to execute
      * @param <D>  the result type produced by the task
      * @return a new {@code Retryable}
+     * @throws NullPointerException if {@code task} is null
      */
     public static <D> Retryable<D> of(@Nonnull Callable<D> task) {
         return new Retryable<>(task);
     }
 
     /**
-     * Sets the validation predicate that must evaluate to {@code true} for the
-     * result to be considered successful. If the predicate returns {@code false}
-     * the task will be retried (subject to {@link #maxRetries(int)} and
-     * delay/back-off settings).
+     * Sets the validation bi-predicate that must evaluate to {@code true} for the
+     * result to be considered successful. The bi-predicate receives both the result
+     * and the current attempt number. If the predicate returns {@code false} the
+     * task will be retried (subject to {@link #maxRetries(int)} and delay/back-off
+     * settings).
      * <p>
-     * <strong>Note:</strong> If the predicate itself throws an exception, that
+     * <strong>Note:</strong> If the bi-predicate itself throws an exception, that
      * exception will propagate immediately and will not trigger a retry. Such
      * exceptions typically indicate logic errors in the predicate implementation.
      * </p>
      *
-     * @param predicate validation predicate (must not be {@code null})
+     * @param predicate validation bi-predicate that accepts the result and attempt
+     *                  number (must not be {@code null})
      * @return this instance for chaining
+     * @throws NullPointerException if {@code predicate} is null
      */
-    public Retryable<R> retryUntilResult(@Nonnull Predicate<? super R> predicate) {
+    public Retryable<R> retryUntilResult(@Nonnull BiPredicate<? super R, Integer> predicate) {
         this.resultPredicate = Objects.requireNonNull(predicate);
         return this;
     }
 
     /**
-     * Defines which exceptions qualify for a retry by supplying a predicate.
+     * Defines which exceptions qualify for a retry by supplying a bi-predicate. The
+     * bi-predicate receives both the exception and the current attempt number.
      * <p>
-     * <strong>Note:</strong> If the predicate itself throws an exception, that
+     * <strong>Note:</strong> If the bi-predicate itself throws an exception, that
      * exception will propagate immediately and will not trigger a retry. Such
      * exceptions typically indicate logic errors in the predicate implementation.
      * </p>
      *
-     * @param predicate predicate deciding whether an exception is retryable
+     * @param predicate bi-predicate deciding whether an exception is retryable
+     *                  based on the exception and attempt number
      * @return this instance for chaining
+     * @throws NullPointerException if {@code predicate} is null
      */
-    public Retryable<R> retryOnFailure(@Nonnull Predicate<? super Exception> predicate) {
+    public Retryable<R> retryOnFailure(@Nonnull BiPredicate<? super Exception, Integer> predicate) {
         this.exceptionPredicate = Objects.requireNonNull(predicate);
         return this;
     }
 
     /**
-     * Defines which exceptions should not trigger a retry by supplying a predicate.
-     * When an exception matches this predicate, the retryable will immediately
-     * return a failure outcome without attempting any retries.
+     * Defines which exceptions should not trigger a retry by supplying a
+     * bi-predicate. When an exception matches this bi-predicate, the retryable will
+     * immediately return a failure outcome without attempting any retries. The
+     * bi-predicate receives both the exception and the current attempt number.
      * <p>
-     * This is the opposite of {@link #retryOnFailure(Predicate)}. If an exception
-     * matches both predicates, {@code noRetryExceptionPredicate} takes precedence.
+     * This is the opposite of {@link #retryOnFailure(BiPredicate)}. If an exception
+     * matches both predicates, {@code noRetryOnFailure} takes precedence.
      * </p>
      * <p>
-     * <strong>Note:</strong> If the predicate itself throws an exception, that
+     * <strong>Note:</strong> If the bi-predicate itself throws an exception, that
      * exception will propagate immediately and will not trigger a retry. Such
      * exceptions typically indicate logic errors in the predicate implementation.
      * </p>
      *
-     * @param predicate predicate deciding whether an exception should not be
-     *                  retried
+     * @param predicate bi-predicate deciding whether an exception should not be
+     *                  retried based on the exception and attempt number
      * @return this instance for chaining
+     * @throws NullPointerException if {@code predicate} is null
      */
-    public Retryable<R> noRetryOnFailure(@Nonnull Predicate<? super Exception> predicate) {
+    public Retryable<R> noRetryOnFailure(@Nonnull BiPredicate<? super Exception, Integer> predicate) {
         this.noRetryOnFailure = Objects.requireNonNull(predicate);
         return this;
     }
@@ -145,7 +157,8 @@ public final class Retryable<R> implements Callable<Retryable.Outcome<R>> {
      * enforced—use care when supplying very large numbers as they may lead to
      * long-running loops.
      *
-     * @param maxRetries number of retries to permit (must be &gt;= 0)
+     * @param maxRetries number of retries to permit (negative values are normalized
+     *                   to 0)
      * @return this instance for fluent chaining
      */
     public Retryable<R> maxRetries(int maxRetries) {
@@ -166,6 +179,7 @@ public final class Retryable<R> implements Callable<Retryable.Outcome<R>> {
      * @param unit     unit for the duration; any unit
      * @return this instance for method chaining
      * @throws IllegalArgumentException if {@code duration} is negative
+     * @throws NullPointerException     if {@code unit} is null
      */
     public Retryable<R> baseDelay(long duration, @Nonnull TimeUnit unit) {
         Objects.requireNonNull(unit);
@@ -179,8 +193,9 @@ public final class Retryable<R> implements Callable<Retryable.Outcome<R>> {
     /**
      * Selects the back-off strategy to compute the delay before the next retry.
      *
-     * @param strategy the {@link Backoff} strategy to apply
+     * @param strategy the {@link BackoffStrategy} to apply
      * @return this instance for method chaining
+     * @throws NullPointerException if {@code strategy} is null
      */
     public Retryable<R> backoff(@Nonnull BackoffStrategy strategy) {
         this.backoffStrategy = Objects.requireNonNull(strategy);
@@ -205,7 +220,6 @@ public final class Retryable<R> implements Callable<Retryable.Outcome<R>> {
      *
      * @return a {@link Outcome} that captures success/failure, number of attempts
      *         and stop reason
-     * @throws RuntimeException if an unexpected error occurs during execution
      */
     @Override
     public Outcome<R> call() {
@@ -224,18 +238,21 @@ public final class Retryable<R> implements Callable<Retryable.Outcome<R>> {
             }
 
             if (taskException == null) {
-                if (resultPredicate.test(value))
+                if (resultPredicate.test(value, attempt)) {
                     return Outcome.success(value, attempt);
+                }
+                // Result validation failed, will retry if max retries not exceeded
             } else {
-                if (noRetryOnFailure.test(taskException))
+                if (noRetryOnFailure.test(taskException, attempt))
                     return Outcome.failure(taskException, attempt, ABORTED_SKIP_RETRY_EXCEPTION);
-                if (!exceptionPredicate.test(taskException))
+                if (!exceptionPredicate.test(taskException, attempt))
                     return Outcome.failure(taskException, attempt, ABORTED_NON_RETRYABLE_EXCEPTION);
                 error = taskException;
             }
 
             if (attempt > maxRetries) {
-                reason = (error == null) ? RETRIES_EXHAUSTED_INVALID_RESULT : RETRIES_EXHAUSTED_RETRYABLE_EXCEPTION;
+                reason = taskException == null ? RETRIES_EXHAUSTED_INVALID_RESULT
+                        : RETRIES_EXHAUSTED_RETRYABLE_EXCEPTION;
                 break;
             }
 
@@ -264,22 +281,44 @@ public final class Retryable<R> implements Callable<Retryable.Outcome<R>> {
      * {@link #backoff(BackoffStrategy)}.
      */
     public interface BackoffStrategy {
+        /**
+         * Calculates the delay before the next retry attempt.
+         *
+         * @param base    the base delay in milliseconds
+         * @param attempt the current attempt number (1-based)
+         * @return the delay in milliseconds before the next attempt
+         */
         long nextDelay(long base, int attempt);
     }
 
+    /**
+     * Built-in backoff strategies for retry delays.
+     */
     public enum Backoff implements BackoffStrategy {
+        /**
+         * Fixed delay strategy that returns the same base delay for each attempt.
+         */
         FIXED {
             @Override
             public long nextDelay(long base, int attempt) {
                 return base;
             }
         },
+        /**
+         * Linear backoff strategy that multiplies the base delay by the attempt number.
+         * For example, base, base*2, base*3, base*4, etc.
+         */
         LINEAR {
             @Override
             public long nextDelay(long base, int attempt) {
                 return base * attempt;
             }
         },
+        /**
+         * Exponential backoff strategy that doubles the delay with each attempt. For
+         * example, base, base*2, base*4, base*8, etc. Overflow protection ensures the
+         * delay never exceeds {@link Long#MAX_VALUE}.
+         */
         EXPONENTIAL {
             @Override
             public long nextDelay(long base, int attempt) {
@@ -306,40 +345,74 @@ public final class Retryable<R> implements Callable<Retryable.Outcome<R>> {
 
     /**
      * Immutable value object describing the outcome of a {@link Retryable#run()}
-     * call.
+     * call. This class extends {@link AbstractOutcome} to provide common outcome
+     * functionality with success/failure semantics.
      */
     @Getter
-    @RequiredArgsConstructor
-    public static final class Outcome<T> {
+    public static final class Outcome<T> extends AbstractOutcome<T, Exception> {
+
+        /**
+         * Enumeration of possible termination reasons for retry execution.
+         */
         public enum TerminationReason {
+            /**
+             * The task succeeded and result validation passed.
+             */
             SUCCEEDED,
+            /**
+             * Maximum retries were exceeded due to result validation failures.
+             */
             RETRIES_EXHAUSTED_INVALID_RESULT,
+            /**
+             * Maximum retries were exceeded due to retryable exceptions.
+             */
             RETRIES_EXHAUSTED_RETRYABLE_EXCEPTION,
+            /**
+             * Execution was aborted due to a non-retryable exception.
+             */
             ABORTED_NON_RETRYABLE_EXCEPTION,
+            /**
+             * Execution was aborted due to an exception matching the no-retry predicate.
+             */
             ABORTED_SKIP_RETRY_EXCEPTION,
+            /**
+             * Execution was interrupted while waiting between attempts.
+             */
             INTERRUPTED
         }
 
-        private final boolean success;
-
         private final int attempts;
-
-        private final T data;
-
-        private final Exception error;
 
         private final TerminationReason reason;
 
+        Outcome(int attempts, T data, Exception error, TerminationReason reason) {
+            super(data, error);
+            this.attempts = attempts;
+            this.reason = reason;
+        }
+
         static <T> Outcome<T> success(T data, int attempts) {
-            return new Outcome<>(true, attempts, data, null, TerminationReason.SUCCEEDED);
+            return new Outcome<>(attempts, data, null, TerminationReason.SUCCEEDED);
         }
 
         static <T> Outcome<T> failure(Exception error, int attempts, TerminationReason reason) {
-            return new Outcome<>(false, attempts, null, error, reason);
+            return new Outcome<>(attempts, null, error, reason);
         }
 
+        /**
+         * Converts this outcome to a {@link Result}.
+         *
+         * @return a {@link Result} representing the success or failure of the retry
+         *         operation
+         */
         public Result<T, Exception> toResult() {
-            return success ? Result.success(data) : Result.failure(error);
+            return isFailure() ? Result.failure(getError()) : Result.success(getData());
         }
+
+        @Override
+        public boolean isFailure() {
+            return !Objects.equals(SUCCEEDED, this.reason);
+        }
+
     }
 }

--- a/src/test/java/org/zeplinko/commons/lang/ext/util/RetryableTest.java
+++ b/src/test/java/org/zeplinko/commons/lang/ext/util/RetryableTest.java
@@ -27,7 +27,7 @@ class RetryableTest {
     @DisplayName("Should return success immediately when result is valid")
     void shouldReturnSuccessImmediatelyWhenResultIsValid() {
         Retryable<Integer> retryable = Retryable.of(() -> 42)
-                .retryUntilResult(r -> r % 2 == 0)
+                .retryUntilResult((r, attempt) -> r % 2 == 0)
                 .maxRetries(3)
                 .baseDelay(0, TimeUnit.MILLISECONDS);
 
@@ -50,7 +50,7 @@ class RetryableTest {
     void shouldRetryUntilValidationPasses() {
         AtomicInteger counter = new AtomicInteger();
         Retryable<Integer> retryable = Retryable.of(counter::incrementAndGet)
-                .retryUntilResult(r -> r % 2 == 0)
+                .retryUntilResult((r, attempt) -> r % 2 == 0)
                 .maxRetries(3)
                 .baseDelay(0, TimeUnit.MILLISECONDS);
 
@@ -74,7 +74,7 @@ class RetryableTest {
             attemptCounter.incrementAndGet();
             return 1;
         })
-                .retryUntilResult(r -> r % 2 == 0)
+                .retryUntilResult((r, attempt) -> r % 2 == 0)
                 .maxRetries(1)
                 .baseDelay(0, TimeUnit.MILLISECONDS);
 
@@ -100,8 +100,8 @@ class RetryableTest {
             }
             return 100;
         })
-                .retryOnFailure(e -> e instanceof IOException)
-                .retryUntilResult(r -> true)
+                .retryOnFailure((e, attempt) -> e instanceof IOException)
+                .retryUntilResult((r, attempt) -> true)
                 .maxRetries(2)
                 .baseDelay(0, TimeUnit.MILLISECONDS);
 
@@ -124,7 +124,7 @@ class RetryableTest {
             counter.incrementAndGet();
             throw new IllegalArgumentException("IllegalArgumentException");
         })
-                .retryOnFailure(e -> e instanceof IOException)
+                .retryOnFailure((e, attempt) -> e instanceof IOException)
                 .maxRetries(3)
                 .baseDelay(0, TimeUnit.MILLISECONDS);
 
@@ -147,7 +147,7 @@ class RetryableTest {
             counter.incrementAndGet();
             throw new IOException("IOException");
         })
-                .retryOnFailure(e -> e instanceof IOException)
+                .retryOnFailure((e, attempt) -> e instanceof IOException)
                 .maxRetries(3)
                 .baseDelay(0, TimeUnit.MILLISECONDS);
 
@@ -171,7 +171,7 @@ class RetryableTest {
             counter.incrementAndGet();
             return 1;
         })
-                .retryUntilResult(r -> false)
+                .retryUntilResult((r, attempt) -> false)
                 .maxRetries(requestedRetries)
                 .baseDelay(0, TimeUnit.MILLISECONDS);
 
@@ -189,7 +189,7 @@ class RetryableTest {
     @DisplayName("Should return failure when interrupted during delay")
     void shouldReturnFailureWhenInterruptedDuringDelay() throws InterruptedException {
         Retryable<Integer> retryable = Retryable.of(() -> 1)
-                .retryUntilResult(r -> false)
+                .retryUntilResult((r, attempt) -> false)
                 .maxRetries(1)
                 .baseDelay(1000, TimeUnit.MILLISECONDS);
 
@@ -242,7 +242,7 @@ class RetryableTest {
             int attempt = counter.incrementAndGet();
             return attempt == retries + 1 ? 123 : 0;
         })
-                .retryUntilResult(r -> r == 123)
+                .retryUntilResult((r, attempt) -> r == 123)
                 .maxRetries(retries)
                 .baseDelay(baseDelay, TimeUnit.MILLISECONDS)
                 .backoff(strategy);
@@ -313,7 +313,7 @@ class RetryableTest {
             int att = counter.incrementAndGet();
             return att == 2 ? 7 : 0;
         })
-                .retryUntilResult(r -> r == 7)
+                .retryUntilResult((r, attempt) -> r == 7)
                 .maxRetries(1)
                 .baseDelay(10, TimeUnit.MILLISECONDS)
                 .backoff(tripleBackoff);
@@ -394,7 +394,7 @@ class RetryableTest {
         AtomicInteger counter = new AtomicInteger();
 
         Retryable<Integer> retryable = Retryable.of(counter::incrementAndGet)
-                .retryUntilResult(r -> false) // always invalid
+                .retryUntilResult((r, attempt) -> false) // always invalid
                 .maxRetries(2)
                 .baseDelay(0, TimeUnit.MILLISECONDS);
 
@@ -422,7 +422,7 @@ class RetryableTest {
                 return 1; // Will fail validation
             }
         })
-                .retryUntilResult(r -> r == 100)
+                .retryUntilResult((r, attempt) -> r == 100)
                 .baseDelay(0, TimeUnit.MILLISECONDS);
 
         // First run - should fail (odd attempt)
@@ -473,7 +473,7 @@ class RetryableTest {
             }
             return "Success on attempt " + attempt;
         })
-                .retryOnFailure(e -> e instanceof IOException)
+                .retryOnFailure((e, attempt) -> e instanceof IOException)
                 .maxRetries(2)
                 .baseDelay(1, TimeUnit.MILLISECONDS);
 
@@ -510,7 +510,7 @@ class RetryableTest {
             }
             return 42;
         })
-                .retryUntilResult(r -> r == 42)
+                .retryUntilResult((r, attempt) -> r == 42)
                 .maxRetries(3)
                 .baseDelay(1, TimeUnit.MILLISECONDS);
 
@@ -608,7 +608,7 @@ class RetryableTest {
                     throw new RuntimeException("Simulated failure");
                 }
             })
-                    .retryOnFailure(e -> e instanceof RuntimeException)
+                    .retryOnFailure((e, attempt) -> e instanceof RuntimeException)
                     .maxRetries(2)
                     .baseDelay(1, TimeUnit.MILLISECONDS);
 
@@ -626,7 +626,7 @@ class RetryableTest {
             taskCounter.incrementAndGet();
             return 42;
         })
-                .retryUntilResult(r -> {
+                .retryUntilResult((r, attempt) -> {
                     throw new IllegalStateException("Predicate logic error");
                 })
                 .maxRetries(3);
@@ -647,7 +647,7 @@ class RetryableTest {
             taskCounter.incrementAndGet();
             throw new IOException("Task failure");
         })
-                .retryOnFailure(e -> {
+                .retryOnFailure((e, attempt) -> {
                     throw new IllegalArgumentException("Exception predicate logic error");
                 })
                 .maxRetries(3);
@@ -669,7 +669,7 @@ class RetryableTest {
             counter.incrementAndGet();
             throw new IllegalArgumentException("Should not retry this");
         })
-                .noRetryOnFailure(e -> e instanceof IllegalArgumentException)
+                .noRetryOnFailure((e, attempt) -> e instanceof IllegalArgumentException)
                 .maxRetries(3)
                 .baseDelay(0, TimeUnit.MILLISECONDS);
 
@@ -695,8 +695,8 @@ class RetryableTest {
             counter.incrementAndGet();
             throw new IOException("Should retry this");
         })
-                .noRetryOnFailure(e -> e instanceof IllegalArgumentException)
-                .retryOnFailure(e -> e instanceof IOException)
+                .noRetryOnFailure((e, attempt) -> e instanceof IllegalArgumentException)
+                .retryOnFailure((e, attempt) -> e instanceof IOException)
                 .maxRetries(2)
                 .baseDelay(0, TimeUnit.MILLISECONDS);
 
@@ -721,8 +721,8 @@ class RetryableTest {
             counter.incrementAndGet();
             throw new RuntimeException("Both predicates match");
         })
-                .retryOnFailure(e -> e instanceof RuntimeException)
-                .noRetryOnFailure(e -> e instanceof RuntimeException)
+                .retryOnFailure((e, attempt) -> e instanceof RuntimeException)
+                .noRetryOnFailure((e, attempt) -> e instanceof RuntimeException)
                 .maxRetries(3)
                 .baseDelay(0, TimeUnit.MILLISECONDS);
 
@@ -774,8 +774,8 @@ class RetryableTest {
             counter.incrementAndGet();
             throw new IOException("Should retry this");
         })
-                .noRetryOnFailure(e -> false) // Never block retries
-                .retryOnFailure(e -> e instanceof IOException) // Allow retry on IOException
+                .noRetryOnFailure((e, attempt) -> false) // Never block retries
+                .retryOnFailure((e, attempt) -> e instanceof IOException) // Allow retry on IOException
                 .maxRetries(2)
                 .baseDelay(0, TimeUnit.MILLISECONDS);
 
@@ -800,7 +800,7 @@ class RetryableTest {
             taskCounter.incrementAndGet();
             throw new IOException("Task failure");
         })
-                .noRetryOnFailure(e -> {
+                .noRetryOnFailure((e, attempt) -> {
                     throw new IllegalStateException("noRetryExceptionPredicate predicate logic error");
                 })
                 .maxRetries(3);


### PR DESCRIPTION
- `Retryable.Outcome` now extends `AbstractOutcome`
- Refactored `retryUntilResult`, `retryOnFailure`, and `noRetryOnFailure` all to use BiPredicate with second argument being the current attempt count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retry logic now supports attempt-aware conditions, allowing predicates to consider both the result/exception and the current attempt number.
  * Enhanced outcome handling with improved conversion and failure indication methods.

* **Bug Fixes**
  * Added null checks for configuration parameters to prevent unexpected errors.

* **Documentation**
  * Expanded and clarified documentation for retry behavior, backoff strategies, and error handling.

* **Refactor**
  * Refactored outcome representation for consistency and maintainability.

* **Tests**
  * Updated test cases to use attempt-aware predicates for retry conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->