### PR TITLE
chore: #86 | Deprecate Container Constructor

### DIFF
--- a/src/main/java/org/zeplinko/commons/lang/ext/core/Container.java
+++ b/src/main/java/org/zeplinko/commons/lang/ext/core/Container.java
@@ -20,8 +20,11 @@ public class Container<T> {
     /**
      * Constructs a new {@code Container} with the specified value.
      *
+     * @deprecated Instead use {@link Container#of(Object)}
+     *
      * @param value The value to be stored in the container. Can be {@code null}.
      */
+    @Deprecated
     public Container(T value) {
         this.value = value;
     }

--- a/src/main/java/org/zeplinko/commons/lang/ext/core/Either.java
+++ b/src/main/java/org/zeplinko/commons/lang/ext/core/Either.java
@@ -34,7 +34,7 @@ public class Either<L, R> {
      * @return An {@code Either} containing the left value.
      */
     public static <L, R> Either<L, R> left(L left) {
-        Container<L> leftContainer = new Container<>(left);
+        Container<L> leftContainer = Container.of(left);
         return new Either<>(leftContainer, null);
     }
 
@@ -47,7 +47,7 @@ public class Either<L, R> {
      * @return An {@code Either} containing the right value.
      */
     public static <L, R> Either<L, R> right(R right) {
-        Container<R> rightContainer = new Container<>(right);
+        Container<R> rightContainer = Container.of(right);
         return new Either<>(null, rightContainer);
     }
 

--- a/src/test/java/org/zeplinko/commons/lang/ext/core/ContainerTest.java
+++ b/src/test/java/org/zeplinko/commons/lang/ext/core/ContainerTest.java
@@ -42,14 +42,14 @@ class ContainerTest {
     @Test
     void test_givenNonNullValue_whenGetValueIsCalled_thenCorrectValueIsReturned() {
         String data = "test value";
-        Container<String> container = new Container<>(data);
+        Container<String> container = Container.of(data);
 
         assertSame(data, container.getValue());
     }
 
     @Test
     void test_givenNullValue_whenGetValueIsCalled_thenNullIsReturned() {
-        Container<String> container = new Container<>(null);
+        Container<String> container = Container.of(null);
 
         assertNull(container.getValue());
     }
@@ -57,7 +57,7 @@ class ContainerTest {
     @Test
     void test_givenIntegerValue_whenGetValueIsCalled_thenCorrectValueIsReturned() {
         Integer data = 123;
-        Container<Integer> container = new Container<>(data);
+        Container<Integer> container = Container.of(data);
 
         assertEquals(123, container.getValue());
     }
@@ -65,7 +65,7 @@ class ContainerTest {
     @Test
     void test_givenCustomObjectValue_whenGetValueIsCalled_thenCorrectObjectIsReturned() {
         MyCustomClass customObject = new MyCustomClass("custom value");
-        Container<MyCustomClass> container = new Container<>(customObject);
+        Container<MyCustomClass> container = Container.of(customObject);
 
         assertSame(customObject, container.getValue());
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated usage of the `Container` constructor to the recommended static factory method in both core logic and tests.

* **Documentation**
  * Marked the `Container(T value)` constructor as deprecated and updated its documentation to suggest using `Container.of(Object)` instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->