### PR TITLE
feature: #95 | Add composition, toUnchecked, identity, and ThrowingPredicate to throwing functional interfaces

### DIFF
--- a/src/main/java/org/zeplinko/commons/lang/ext/util/function/ThrowingBiConsumer.java
+++ b/src/main/java/org/zeplinko/commons/lang/ext/util/function/ThrowingBiConsumer.java
@@ -1,5 +1,8 @@
 package org.zeplinko.commons.lang.ext.util.function;
 
+import java.util.Objects;
+import java.util.function.BiConsumer;
+
 /**
  * A {@link java.util.function.BiConsumer}-like functional interface whose
  * {@link #accept(Object, Object)} method is allowed to throw a checked
@@ -26,4 +29,39 @@ public interface ThrowingBiConsumer<T, U> {
      * @throws Exception if the operation fails
      */
     void accept(T t, U u) throws Exception;
+
+    /**
+     * Returns a composed consumer that performs, in sequence, this operation
+     * followed by the {@code after} operation. If this operation throws, the
+     * {@code after} operation is not performed.
+     *
+     * @param after the operation to perform after this operation
+     * @return a composed consumer
+     */
+    default ThrowingBiConsumer<T, U> andThen(ThrowingBiConsumer<T, U> after) {
+        Objects.requireNonNull(after, "after must not be null");
+        return (t, u) -> {
+            this.accept(t, u);
+            after.accept(t, u);
+        };
+    }
+
+    /**
+     * Returns a standard {@link BiConsumer} that delegates to this consumer,
+     * wrapping any checked exception in a {@link RuntimeException}.
+     *
+     * @return a {@link BiConsumer} that wraps checked exceptions in
+     *         {@link RuntimeException}
+     */
+    default BiConsumer<T, U> toUnchecked() {
+        return (t, u) -> {
+            try {
+                this.accept(t, u);
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
 }

--- a/src/main/java/org/zeplinko/commons/lang/ext/util/function/ThrowingBiFunction.java
+++ b/src/main/java/org/zeplinko/commons/lang/ext/util/function/ThrowingBiFunction.java
@@ -1,5 +1,8 @@
 package org.zeplinko.commons.lang.ext.util.function;
 
+import java.util.Objects;
+import java.util.function.BiFunction;
+
 /**
  * A {@link java.util.function.BiFunction}-like functional interface whose
  * {@link #apply(Object, Object)} method is allowed to throw a checked
@@ -28,4 +31,36 @@ public interface ThrowingBiFunction<T, U, R> {
      * @throws Exception if the operation fails
      */
     R apply(T t, U u) throws Exception;
+
+    /**
+     * Returns a composed function that first applies this function to its inputs,
+     * and then applies the {@code after} function to the result.
+     *
+     * @param <V>   the type of output of the {@code after} function
+     * @param after the function to apply after this function
+     * @return a composed function
+     */
+    default <V> ThrowingBiFunction<T, U, V> andThen(ThrowingFunction<R, V> after) {
+        Objects.requireNonNull(after, "after must not be null");
+        return (t, u) -> after.apply(this.apply(t, u));
+    }
+
+    /**
+     * Returns a standard {@link BiFunction} that delegates to this function,
+     * wrapping any checked exception in a {@link RuntimeException}.
+     *
+     * @return a {@link BiFunction} that wraps checked exceptions in
+     *         {@link RuntimeException}
+     */
+    default BiFunction<T, U, R> toUnchecked() {
+        return (t, u) -> {
+            try {
+                return this.apply(t, u);
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
 }

--- a/src/main/java/org/zeplinko/commons/lang/ext/util/function/ThrowingConsumer.java
+++ b/src/main/java/org/zeplinko/commons/lang/ext/util/function/ThrowingConsumer.java
@@ -1,5 +1,8 @@
 package org.zeplinko.commons.lang.ext.util.function;
 
+import java.util.Objects;
+import java.util.function.Consumer;
+
 /**
  * A {@link java.util.function.Consumer}-like functional interface whose
  * {@link #accept(Object)} method is allowed to throw a checked
@@ -24,4 +27,39 @@ public interface ThrowingConsumer<T> {
      * @throws Exception if the operation fails
      */
     void accept(T t) throws Exception;
+
+    /**
+     * Returns a composed consumer that performs, in sequence, this operation
+     * followed by the {@code after} operation. If this operation throws, the
+     * {@code after} operation is not performed.
+     *
+     * @param after the operation to perform after this operation
+     * @return a composed consumer
+     */
+    default ThrowingConsumer<T> andThen(ThrowingConsumer<T> after) {
+        Objects.requireNonNull(after, "after must not be null");
+        return t -> {
+            this.accept(t);
+            after.accept(t);
+        };
+    }
+
+    /**
+     * Returns a standard {@link Consumer} that delegates to this consumer, wrapping
+     * any checked exception in a {@link RuntimeException}.
+     *
+     * @return a {@link Consumer} that wraps checked exceptions in
+     *         {@link RuntimeException}
+     */
+    default Consumer<T> toUnchecked() {
+        return t -> {
+            try {
+                this.accept(t);
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
 }

--- a/src/main/java/org/zeplinko/commons/lang/ext/util/function/ThrowingFunction.java
+++ b/src/main/java/org/zeplinko/commons/lang/ext/util/function/ThrowingFunction.java
@@ -1,5 +1,8 @@
 package org.zeplinko.commons.lang.ext.util.function;
 
+import java.util.Objects;
+import java.util.function.Function;
+
 /**
  * A {@link java.util.function.Function}-like functional interface whose
  * {@link #apply(Object)} method is allowed to throw a checked
@@ -26,4 +29,64 @@ public interface ThrowingFunction<T, R> {
      * @throws Exception if the operation fails
      */
     R apply(T t) throws Exception;
+
+    /**
+     * Returns a composed function that first applies this function to its input,
+     * and then applies the {@code after} function to the result.
+     *
+     * @param <V>   the type of output of the {@code after} function
+     * @param after the function to apply after this function
+     * @return a composed function
+     */
+    default <V> ThrowingFunction<T, V> andThen(ThrowingFunction<R, V> after) {
+        Objects.requireNonNull(after, "after must not be null");
+        return t -> after.apply(this.apply(t));
+    }
+
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     *
+     * @param <V>    the type of input to the {@code before} function
+     * @param before the function to apply before this function
+     * @return a composed function
+     */
+    default <V> ThrowingFunction<V, R> compose(ThrowingFunction<V, T> before) {
+        Objects.requireNonNull(before, "before must not be null");
+        return v -> this.apply(before.apply(v));
+    }
+
+    /**
+     * Returns a function that always returns its input argument.
+     *
+     * @param <T> the type of the input and output of the function
+     * @return a function that always returns its input argument
+     */
+    static <T> ThrowingFunction<T, T> identity() {
+        return t -> t;
+    }
+
+    /**
+     * Returns a standard {@link Function} that delegates to this function, wrapping
+     * any checked exception in a {@link RuntimeException}.
+     *
+     * <p>
+     * This is useful for using this function in stream pipelines and other contexts
+     * that require a standard {@code Function}.
+     * </p>
+     *
+     * @return a {@link Function} that wraps checked exceptions in
+     *         {@link RuntimeException}
+     */
+    default Function<T, R> toUnchecked() {
+        return t -> {
+            try {
+                return this.apply(t);
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
 }

--- a/src/main/java/org/zeplinko/commons/lang/ext/util/function/ThrowingPredicate.java
+++ b/src/main/java/org/zeplinko/commons/lang/ext/util/function/ThrowingPredicate.java
@@ -1,0 +1,116 @@
+package org.zeplinko.commons.lang.ext.util.function;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * A {@link java.util.function.Predicate}-like functional interface whose
+ * {@link #test(Object)} method is allowed to throw a checked {@link Exception}.
+ *
+ * <p>
+ * This is useful when you want to use lambdas or method references that can
+ * throw checked exceptions in contexts where a {@code Predicate} would normally
+ * be used.
+ * </p>
+ *
+ * @author Shivam&nbsp;Nagpal
+ *
+ * @param <T> the type of the input to the predicate
+ */
+@FunctionalInterface
+public interface ThrowingPredicate<T> {
+    /**
+     * Evaluates this predicate on the given argument.
+     *
+     * @param t the input argument
+     * @return {@code true} if the input argument matches the predicate, otherwise
+     *         {@code false}
+     * @throws Exception if the evaluation fails
+     */
+    boolean test(T t) throws Exception;
+
+    /**
+     * Returns a composed predicate that represents a short-circuit logical AND of
+     * this predicate and the {@code other}. If this predicate evaluates to
+     * {@code false}, the {@code other} predicate is not evaluated.
+     *
+     * @param other the predicate to AND with this predicate
+     * @return a composed predicate
+     */
+    default ThrowingPredicate<T> and(ThrowingPredicate<T> other) {
+        Objects.requireNonNull(other, "other must not be null");
+        return t -> this.test(t) && other.test(t);
+    }
+
+    /**
+     * Returns a composed predicate that represents a short-circuit logical OR of
+     * this predicate and the {@code other}. If this predicate evaluates to
+     * {@code true}, the {@code other} predicate is not evaluated.
+     *
+     * @param other the predicate to OR with this predicate
+     * @return a composed predicate
+     */
+    default ThrowingPredicate<T> or(ThrowingPredicate<T> other) {
+        Objects.requireNonNull(other, "other must not be null");
+        return t -> this.test(t) || other.test(t);
+    }
+
+    /**
+     * Returns a predicate that represents the logical negation of this predicate.
+     *
+     * @return a predicate that negates this predicate
+     */
+    default ThrowingPredicate<T> negate() {
+        return t -> !this.test(t);
+    }
+
+    /**
+     * Returns a predicate that tests if the argument is equal to {@code target}
+     * according to {@link Objects#equals(Object, Object)}. Handles null targets
+     * correctly.
+     *
+     * @param <T>    the type of the input to the predicate
+     * @param target the reference object for equality comparison (may be null)
+     * @return a predicate that tests equality against {@code target}
+     */
+    static <T> ThrowingPredicate<T> isEqual(Object target) {
+        return t -> Objects.equals(target, t);
+    }
+
+    /**
+     * Returns a predicate that is the negation of the supplied predicate. This is
+     * useful as a method reference where a negated predicate is needed.
+     *
+     * @param <T>    the type of the input to the predicate
+     * @param target the predicate to negate
+     * @return a predicate that negates the supplied predicate
+     */
+    static <T> ThrowingPredicate<T> not(ThrowingPredicate<T> target) {
+        Objects.requireNonNull(target, "target must not be null");
+        return target.negate();
+    }
+
+    /**
+     * Returns a standard {@link Predicate} that delegates to this predicate,
+     * wrapping any checked exception in a {@link RuntimeException}.
+     *
+     * <p>
+     * This is useful for using this predicate in stream pipelines and other
+     * contexts that require a standard {@code Predicate}.
+     * </p>
+     *
+     * @return a {@link Predicate} that wraps checked exceptions in
+     *         {@link RuntimeException}
+     */
+    default Predicate<T> toUnchecked() {
+        return t -> {
+            try {
+                return this.test(t);
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+}

--- a/src/main/java/org/zeplinko/commons/lang/ext/util/function/ThrowingRunnable.java
+++ b/src/main/java/org/zeplinko/commons/lang/ext/util/function/ThrowingRunnable.java
@@ -21,4 +21,23 @@ public interface ThrowingRunnable {
      * @throws Exception if the operation fails
      */
     void run() throws Exception;
+
+    /**
+     * Returns a standard {@link Runnable} that delegates to this runnable, wrapping
+     * any checked exception in a {@link RuntimeException}.
+     *
+     * @return a {@link Runnable} that wraps checked exceptions in
+     *         {@link RuntimeException}
+     */
+    default Runnable toUnchecked() {
+        return () -> {
+            try {
+                this.run();
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
 }

--- a/src/main/java/org/zeplinko/commons/lang/ext/util/function/ThrowingSupplier.java
+++ b/src/main/java/org/zeplinko/commons/lang/ext/util/function/ThrowingSupplier.java
@@ -1,5 +1,7 @@
 package org.zeplinko.commons.lang.ext.util.function;
 
+import java.util.function.Supplier;
+
 /**
  * A {@link java.util.function.Supplier}-like functional interface whose
  * {@link #get()} method is allowed to throw a checked {@link Exception}.
@@ -23,4 +25,23 @@ public interface ThrowingSupplier<T> {
      * @throws Exception if the operation fails
      */
     T get() throws Exception;
+
+    /**
+     * Returns a standard {@link Supplier} that delegates to this supplier, wrapping
+     * any checked exception in a {@link RuntimeException}.
+     *
+     * @return a {@link Supplier} that wraps checked exceptions in
+     *         {@link RuntimeException}
+     */
+    default Supplier<T> toUnchecked() {
+        return () -> {
+            try {
+                return this.get();
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
 }

--- a/src/test/java/org/zeplinko/commons/lang/ext/util/function/ThrowingBiConsumerTest.java
+++ b/src/test/java/org/zeplinko/commons/lang/ext/util/function/ThrowingBiConsumerTest.java
@@ -3,8 +3,12 @@ package org.zeplinko.commons.lang.ext.util.function;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -50,5 +54,82 @@ class ThrowingBiConsumerTest {
         assertEquals(1, map.get("one"));
         assertEquals(2, map.get("two"));
         assertEquals(3, map.get("three"));
+    }
+
+    @Test
+    void test_whenAndThenIsInvoked_thenBothConsumersAreExecuted() throws Exception {
+        List<String> log = new ArrayList<>();
+        ThrowingBiConsumer<String, Integer> first = (k, v) -> log.add("first:" + k + v);
+        ThrowingBiConsumer<String, Integer> second = (k, v) -> log.add("second:" + k + v);
+        first.andThen(second).accept("x", 1);
+        assertEquals(Arrays.asList("first:x1", "second:x1"), log);
+    }
+
+    @Test
+    void test_whenAndThenFirstConsumerThrows_thenSecondConsumerNotCalled() {
+        List<String> log = new ArrayList<>();
+        ThrowingBiConsumer<String, Integer> first = (k, v) -> {
+            throw new IOException("first failed");
+        };
+        ThrowingBiConsumer<String, Integer> second = (k, v) -> log.add("second");
+        assertThrows(IOException.class, () -> first.andThen(second).accept("x", 1));
+        assertTrue(log.isEmpty());
+    }
+
+    @Test
+    void test_whenAndThenCalledWithNull_thenThrowsNullPointerException() {
+        ThrowingBiConsumer<String, Integer> c = (k, v) -> {
+        };
+        assertThrows(NullPointerException.class, () -> c.andThen(null));
+    }
+
+    @Test
+    void test_whenAndThenSecondConsumerThrows_thenExceptionPropagated() {
+        List<String> log = new ArrayList<>();
+        ThrowingBiConsumer<String, Integer> first = (k, v) -> log.add("first:" + k + v);
+        ThrowingBiConsumer<String, Integer> second = (k, v) -> {
+            throw new IOException("second failed");
+        };
+        assertThrows(IOException.class, () -> first.andThen(second).accept("x", 1));
+        assertEquals(Arrays.asList("first:x1"), log);
+    }
+
+    @Test
+    void test_whenToUncheckedIsInvoked_thenReturnsStandardBiConsumer() {
+        Map<String, Integer> map = new HashMap<>();
+        ThrowingBiConsumer<String, Integer> throwing = map::put;
+        BiConsumer<String, Integer> standard = throwing.toUnchecked();
+        standard.accept("key", 42);
+        assertEquals(42, map.get("key"));
+    }
+
+    @Test
+    void test_whenToUncheckedThrows_thenRethrowsAsRuntimeException() {
+        ThrowingBiConsumer<String, Integer> throwing = (k, v) -> {
+            throw new IOException("io error");
+        };
+        BiConsumer<String, Integer> standard = throwing.toUnchecked();
+        assertThrows(RuntimeException.class, () -> standard.accept("k", 1));
+    }
+
+    @Test
+    void test_whenToUncheckedThrows_thenOriginalExceptionIsWrapped() {
+        IOException cause = new IOException("io error");
+        ThrowingBiConsumer<String, Integer> throwing = (k, v) -> {
+            throw cause;
+        };
+        BiConsumer<String, Integer> standard = throwing.toUnchecked();
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> standard.accept("k", 1));
+        assertSame(cause, ex.getCause());
+    }
+
+    @Test
+    void test_whenToUncheckedThrowsRuntimeException_thenNotWrapped() {
+        IllegalArgumentException original = new IllegalArgumentException("direct");
+        ThrowingBiConsumer<String, Integer> throwing = (k, v) -> {
+            throw original;
+        };
+        RuntimeException ex = assertThrows(IllegalArgumentException.class, () -> throwing.toUnchecked().accept("k", 1));
+        assertSame(original, ex);
     }
 }

--- a/src/test/java/org/zeplinko/commons/lang/ext/util/function/ThrowingBiFunctionTest.java
+++ b/src/test/java/org/zeplinko/commons/lang/ext/util/function/ThrowingBiFunctionTest.java
@@ -3,6 +3,7 @@ package org.zeplinko.commons.lang.ext.util.function;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.function.BiFunction;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -54,5 +55,79 @@ class ThrowingBiFunctionTest {
         ThrowingBiFunction<String, String, String> function = (first, second) -> null;
         String result = function.apply("a", "b");
         assertNull(result);
+    }
+
+    @Test
+    void test_whenAndThenIsInvoked_thenAppliesAfterFunction() throws Exception {
+        ThrowingBiFunction<Integer, Integer, Integer> sum = Integer::sum;
+        ThrowingFunction<Integer, String> stringify = i -> "result=" + i;
+        ThrowingBiFunction<Integer, Integer, String> composed = sum.andThen(stringify);
+        assertEquals("result=8", composed.apply(5, 3));
+    }
+
+    @Test
+    void test_whenAndThenBiFunctionThrows_thenExceptionPropagated() {
+        ThrowingBiFunction<String, String, String> biFunction = (a, b) -> {
+            throw new IOException("bi failed");
+        };
+        ThrowingFunction<String, Integer> after = String::length;
+        ThrowingBiFunction<String, String, Integer> composed = biFunction.andThen(after);
+        assertThrows(IOException.class, () -> composed.apply("a", "b"));
+    }
+
+    @Test
+    void test_whenAndThenAfterFunctionThrows_thenExceptionPropagated() {
+        ThrowingBiFunction<Integer, Integer, Integer> sum = Integer::sum;
+        ThrowingFunction<Integer, String> after = i -> {
+            throw new IOException("after failed");
+        };
+        ThrowingBiFunction<Integer, Integer, String> composed = sum.andThen(after);
+        assertThrows(IOException.class, () -> composed.apply(1, 2));
+    }
+
+    @Test
+    void test_whenAndThenCalledWithNull_thenThrowsNullPointerException() {
+        ThrowingBiFunction<Integer, Integer, Integer> f = Integer::sum;
+        assertThrows(NullPointerException.class, () -> f.andThen(null));
+    }
+
+    @Test
+    void test_whenToUncheckedIsInvoked_thenReturnsStandardBiFunction() {
+        ThrowingBiFunction<Integer, Integer, Integer> throwing = Integer::sum;
+        BiFunction<Integer, Integer, Integer> standard = throwing.toUnchecked();
+        assertEquals(8, standard.apply(5, 3));
+    }
+
+    @Test
+    void test_whenToUncheckedThrows_thenRethrowsAsRuntimeException() {
+        ThrowingBiFunction<String, String, String> throwing = (a, b) -> {
+            throw new IOException("io error");
+        };
+        BiFunction<String, String, String> standard = throwing.toUnchecked();
+        assertThrows(RuntimeException.class, () -> standard.apply("a", "b"));
+    }
+
+    @Test
+    void test_whenToUncheckedThrows_thenOriginalExceptionIsWrapped() {
+        IOException cause = new IOException("io error");
+        ThrowingBiFunction<String, String, String> throwing = (a, b) -> {
+            throw cause;
+        };
+        BiFunction<String, String, String> standard = throwing.toUnchecked();
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> standard.apply("a", "b"));
+        assertSame(cause, ex.getCause());
+    }
+
+    @Test
+    void test_whenToUncheckedThrowsRuntimeException_thenNotWrapped() {
+        IllegalArgumentException original = new IllegalArgumentException("direct");
+        ThrowingBiFunction<String, String, String> throwing = (a, b) -> {
+            throw original;
+        };
+        RuntimeException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> throwing.toUnchecked().apply("a", "b")
+        );
+        assertSame(original, ex);
     }
 }

--- a/src/test/java/org/zeplinko/commons/lang/ext/util/function/ThrowingConsumerTest.java
+++ b/src/test/java/org/zeplinko/commons/lang/ext/util/function/ThrowingConsumerTest.java
@@ -4,7 +4,9 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -59,5 +61,82 @@ class ThrowingConsumerTest {
         consumer.accept(array);
         assertEquals(1, list.size());
         assertSame(array, list.get(0));
+    }
+
+    @Test
+    void test_whenAndThenIsInvoked_thenBothConsumersAreExecuted() throws Exception {
+        List<String> log = new ArrayList<>();
+        ThrowingConsumer<String> first = s -> log.add("first:" + s);
+        ThrowingConsumer<String> second = s -> log.add("second:" + s);
+        first.andThen(second).accept("x");
+        assertEquals(Arrays.asList("first:x", "second:x"), log);
+    }
+
+    @Test
+    void test_whenAndThenFirstConsumerThrows_thenSecondConsumerNotCalled() {
+        List<String> log = new ArrayList<>();
+        ThrowingConsumer<String> first = s -> {
+            throw new IOException("first failed");
+        };
+        ThrowingConsumer<String> second = s -> log.add("second");
+        assertThrows(IOException.class, () -> first.andThen(second).accept("x"));
+        assertTrue(log.isEmpty());
+    }
+
+    @Test
+    void test_whenAndThenCalledWithNull_thenThrowsNullPointerException() {
+        ThrowingConsumer<String> c = s -> {
+        };
+        assertThrows(NullPointerException.class, () -> c.andThen(null));
+    }
+
+    @Test
+    void test_whenAndThenSecondConsumerThrows_thenExceptionPropagated() {
+        List<String> log = new ArrayList<>();
+        ThrowingConsumer<String> first = s -> log.add("first:" + s);
+        ThrowingConsumer<String> second = s -> {
+            throw new IOException("second failed");
+        };
+        assertThrows(IOException.class, () -> first.andThen(second).accept("x"));
+        assertEquals(Arrays.asList("first:x"), log);
+    }
+
+    @Test
+    void test_whenToUncheckedIsInvoked_thenReturnsStandardConsumer() {
+        List<String> log = new ArrayList<>();
+        ThrowingConsumer<String> throwing = log::add;
+        Consumer<String> standard = throwing.toUnchecked();
+        standard.accept("hello");
+        assertEquals(Arrays.asList("hello"), log);
+    }
+
+    @Test
+    void test_whenToUncheckedThrows_thenRethrowsAsRuntimeException() {
+        ThrowingConsumer<String> throwing = s -> {
+            throw new IOException("io error");
+        };
+        Consumer<String> standard = throwing.toUnchecked();
+        assertThrows(RuntimeException.class, () -> standard.accept("x"));
+    }
+
+    @Test
+    void test_whenToUncheckedThrows_thenOriginalExceptionIsWrapped() {
+        IOException cause = new IOException("io error");
+        ThrowingConsumer<String> throwing = s -> {
+            throw cause;
+        };
+        Consumer<String> standard = throwing.toUnchecked();
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> standard.accept("x"));
+        assertSame(cause, ex.getCause());
+    }
+
+    @Test
+    void test_whenToUncheckedThrowsRuntimeException_thenNotWrapped() {
+        IllegalArgumentException original = new IllegalArgumentException("direct");
+        ThrowingConsumer<String> throwing = s -> {
+            throw original;
+        };
+        RuntimeException ex = assertThrows(IllegalArgumentException.class, () -> throwing.toUnchecked().accept("x"));
+        assertSame(original, ex);
     }
 }

--- a/src/test/java/org/zeplinko/commons/lang/ext/util/function/ThrowingFunctionTest.java
+++ b/src/test/java/org/zeplinko/commons/lang/ext/util/function/ThrowingFunctionTest.java
@@ -3,6 +3,7 @@ package org.zeplinko.commons.lang.ext.util.function;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -55,5 +56,127 @@ class ThrowingFunctionTest {
         ThrowingFunction<String, String> function = (value) -> null;
         String result = function.apply("test");
         assertNull(result);
+    }
+
+    @Test
+    void test_whenAndThenIsInvoked_thenAppliesAfterFunction() throws Exception {
+        ThrowingFunction<String, Integer> parse = Integer::parseInt;
+        ThrowingFunction<Integer, String> format = i -> String.format("%04d", i);
+        ThrowingFunction<String, String> composed = parse.andThen(format);
+        assertEquals("0042", composed.apply("42"));
+    }
+
+    @Test
+    void test_whenAndThenFirstFunctionThrows_thenExceptionPropagated() {
+        ThrowingFunction<String, Integer> parse = s -> {
+            throw new IOException("parse failed");
+        };
+        ThrowingFunction<Integer, String> format = Object::toString;
+        ThrowingFunction<String, String> composed = parse.andThen(format);
+        Exception ex = assertThrows(IOException.class, () -> composed.apply("bad"));
+        assertEquals("parse failed", ex.getMessage());
+    }
+
+    @Test
+    void test_whenAndThenSecondFunctionThrows_thenExceptionPropagated() {
+        ThrowingFunction<String, Integer> parse = Integer::parseInt;
+        ThrowingFunction<Integer, String> format = i -> {
+            throw new IOException("format failed");
+        };
+        ThrowingFunction<String, String> composed = parse.andThen(format);
+        Exception ex = assertThrows(IOException.class, () -> composed.apply("42"));
+        assertEquals("format failed", ex.getMessage());
+    }
+
+    @Test
+    void test_whenComposeIsInvoked_thenAppliesBeforeFunction() throws Exception {
+        ThrowingFunction<String, Integer> parse = Integer::parseInt;
+        ThrowingFunction<Integer, String> stringify = i -> i + "!";
+        ThrowingFunction<String, String> composed = stringify.compose(parse);
+        assertEquals("42!", composed.apply("42"));
+    }
+
+    @Test
+    void test_whenComposeBeforeFunctionThrows_thenExceptionPropagated() {
+        ThrowingFunction<String, Integer> parse = s -> {
+            throw new IOException("parse failed");
+        };
+        ThrowingFunction<Integer, String> stringify = Object::toString;
+        ThrowingFunction<String, String> composed = stringify.compose(parse);
+        Exception ex = assertThrows(IOException.class, () -> composed.apply("bad"));
+        assertEquals("parse failed", ex.getMessage());
+    }
+
+    @Test
+    void test_whenToUncheckedIsInvoked_thenReturnsStandardFunction() {
+        ThrowingFunction<String, Integer> throwing = Integer::parseInt;
+        Function<String, Integer> standard = throwing.toUnchecked();
+        assertEquals(42, standard.apply("42"));
+    }
+
+    @Test
+    void test_whenToUncheckedFunctionThrows_thenRethrowsAsRuntimeException() {
+        ThrowingFunction<String, Integer> throwing = s -> {
+            throw new IOException("io error");
+        };
+        Function<String, Integer> standard = throwing.toUnchecked();
+        assertThrows(RuntimeException.class, () -> standard.apply("bad"));
+    }
+
+    @Test
+    void test_whenToUncheckedFunctionThrows_thenOriginalExceptionIsWrapped() {
+        IOException cause = new IOException("io error");
+        ThrowingFunction<String, Integer> throwing = s -> {
+            throw cause;
+        };
+        Function<String, Integer> standard = throwing.toUnchecked();
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> standard.apply("bad"));
+        assertSame(cause, ex.getCause());
+    }
+
+    @Test
+    void test_whenToUncheckedThrowsRuntimeException_thenNotWrapped() {
+        IllegalArgumentException original = new IllegalArgumentException("direct");
+        ThrowingFunction<String, Integer> throwing = s -> {
+            throw original;
+        };
+        RuntimeException ex = assertThrows(IllegalArgumentException.class, () -> throwing.toUnchecked().apply("x"));
+        assertSame(original, ex);
+    }
+
+    @Test
+    void test_whenAndThenCalledWithNull_thenThrowsNullPointerException() {
+        ThrowingFunction<String, Integer> f = Integer::parseInt;
+        assertThrows(NullPointerException.class, () -> f.andThen(null));
+    }
+
+    @Test
+    void test_whenComposeCalledWithNull_thenThrowsNullPointerException() {
+        ThrowingFunction<Integer, String> f = Object::toString;
+        assertThrows(NullPointerException.class, () -> f.compose(null));
+    }
+
+    @Test
+    void test_whenComposeOuterFunctionThrows_thenExceptionPropagated() {
+        ThrowingFunction<String, Integer> parse = Integer::parseInt;
+        ThrowingFunction<Integer, String> stringify = i -> {
+            throw new IOException("stringify failed");
+        };
+        ThrowingFunction<String, String> composed = stringify.compose(parse);
+        Exception ex = assertThrows(IOException.class, () -> composed.apply("42"));
+        assertEquals("stringify failed", ex.getMessage());
+    }
+
+    @Test
+    void test_whenIdentityIsInvoked_thenReturnsSameInstance() throws Exception {
+        ThrowingFunction<String, String> identity = ThrowingFunction.identity();
+        String value = "hello";
+        assertSame(value, identity.apply(value));
+    }
+
+    @Test
+    void test_whenIdentityIsInvokedWithNull_thenReturnsNull() throws Exception {
+        ThrowingFunction<String, String> identity = ThrowingFunction.identity();
+        assertNull(identity.apply(null));
     }
 }

--- a/src/test/java/org/zeplinko/commons/lang/ext/util/function/ThrowingPredicateTest.java
+++ b/src/test/java/org/zeplinko/commons/lang/ext/util/function/ThrowingPredicateTest.java
@@ -1,0 +1,169 @@
+package org.zeplinko.commons.lang.ext.util.function;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ThrowingPredicateTest {
+
+    @Test
+    void test_whenTestIsInvoked_thenEvaluatesPredicate() throws Exception {
+        ThrowingPredicate<String> predicate = s -> s.length() > 3;
+        assertTrue(predicate.test("hello"));
+        assertFalse(predicate.test("hi"));
+    }
+
+    @Test
+    void test_whenTestThrows_thenExceptionPropagated() {
+        ThrowingPredicate<String> predicate = s -> {
+            throw new IOException("test failed");
+        };
+        Exception ex = assertThrows(IOException.class, () -> predicate.test("any"));
+        assertEquals("test failed", ex.getMessage());
+    }
+
+    @Test
+    void test_whenAndIsInvoked_thenBothMustBeTrue() throws Exception {
+        ThrowingPredicate<Integer> positive = i -> i > 0;
+        ThrowingPredicate<Integer> even = i -> i % 2 == 0;
+        ThrowingPredicate<Integer> positiveAndEven = positive.and(even);
+
+        assertTrue(positiveAndEven.test(4));
+        assertFalse(positiveAndEven.test(3));
+        assertFalse(positiveAndEven.test(-2));
+    }
+
+    @Test
+    void test_whenAndShortCircuits_thenSecondNotEvaluated() throws Exception {
+        AtomicBoolean secondCalled = new AtomicBoolean(false);
+        ThrowingPredicate<Integer> alwaysFalse = i -> false;
+        ThrowingPredicate<Integer> recorder = i -> {
+            secondCalled.set(true);
+            return true;
+        };
+
+        assertFalse(alwaysFalse.and(recorder).test(1));
+        assertFalse(secondCalled.get());
+    }
+
+    @Test
+    void test_whenOrIsInvoked_thenEitherSuffices() throws Exception {
+        ThrowingPredicate<Integer> positive = i -> i > 0;
+        ThrowingPredicate<Integer> even = i -> i % 2 == 0;
+        ThrowingPredicate<Integer> positiveOrEven = positive.or(even);
+
+        assertTrue(positiveOrEven.test(3));
+        assertTrue(positiveOrEven.test(-2));
+        assertFalse(positiveOrEven.test(-3));
+    }
+
+    @Test
+    void test_whenOrShortCircuits_thenSecondNotEvaluated() throws Exception {
+        AtomicBoolean secondCalled = new AtomicBoolean(false);
+        ThrowingPredicate<Integer> alwaysTrue = i -> true;
+        ThrowingPredicate<Integer> recorder = i -> {
+            secondCalled.set(true);
+            return false;
+        };
+
+        assertTrue(alwaysTrue.or(recorder).test(1));
+        assertFalse(secondCalled.get());
+    }
+
+    @Test
+    void test_whenNegateIsInvoked_thenInvertsResult() throws Exception {
+        ThrowingPredicate<String> isEmpty = String::isEmpty;
+        ThrowingPredicate<String> isNotEmpty = isEmpty.negate();
+
+        assertFalse(isNotEmpty.test(""));
+        assertTrue(isNotEmpty.test("hello"));
+    }
+
+    @Test
+    void test_whenToUncheckedIsInvoked_thenReturnsStandardPredicate() {
+        ThrowingPredicate<String> throwing = s -> s.length() > 3;
+        Predicate<String> standard = throwing.toUnchecked();
+
+        assertTrue(standard.test("hello"));
+        assertFalse(standard.test("hi"));
+    }
+
+    @Test
+    void test_whenToUncheckedThrows_thenRethrowsAsRuntimeException() {
+        ThrowingPredicate<String> throwing = s -> {
+            throw new IOException("io error");
+        };
+        Predicate<String> standard = throwing.toUnchecked();
+        assertThrows(RuntimeException.class, () -> standard.test("any"));
+    }
+
+    @Test
+    void test_whenToUncheckedThrows_thenOriginalExceptionIsWrapped() {
+        IOException cause = new IOException("io error");
+        ThrowingPredicate<String> throwing = s -> {
+            throw cause;
+        };
+        Predicate<String> standard = throwing.toUnchecked();
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> standard.test("any"));
+        assertSame(cause, ex.getCause());
+    }
+
+    @Test
+    void test_whenToUncheckedThrowsRuntimeException_thenNotWrapped() {
+        IllegalArgumentException original = new IllegalArgumentException("direct");
+        ThrowingPredicate<String> throwing = s -> {
+            throw original;
+        };
+        RuntimeException ex = assertThrows(IllegalArgumentException.class, () -> throwing.toUnchecked().test("any"));
+        assertSame(original, ex);
+    }
+
+    @Test
+    void test_whenAndCalledWithNull_thenThrowsNullPointerException() {
+        ThrowingPredicate<String> p = s -> true;
+        assertThrows(NullPointerException.class, () -> p.and(null));
+    }
+
+    @Test
+    void test_whenOrCalledWithNull_thenThrowsNullPointerException() {
+        ThrowingPredicate<String> p = s -> false;
+        assertThrows(NullPointerException.class, () -> p.or(null));
+    }
+
+    @Test
+    void test_whenNotIsInvoked_thenInvertsResult() throws Exception {
+        ThrowingPredicate<String> isEmpty = String::isEmpty;
+        ThrowingPredicate<String> isNotEmpty = ThrowingPredicate.not(isEmpty);
+        assertFalse(isNotEmpty.test(""));
+        assertTrue(isNotEmpty.test("hello"));
+    }
+
+    @Test
+    void test_whenNotCalledWithNull_thenThrowsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ThrowingPredicate.not(null));
+    }
+
+    @Test
+    void test_whenIsEqualIsInvoked_thenMatchesEqualValues() throws Exception {
+        ThrowingPredicate<String> predicate = ThrowingPredicate.isEqual("hello");
+        assertTrue(predicate.test("hello"));
+        assertFalse(predicate.test("world"));
+    }
+
+    @Test
+    void test_whenIsEqualIsInvokedWithNullTarget_thenMatchesNull() throws Exception {
+        ThrowingPredicate<String> predicate = ThrowingPredicate.isEqual(null);
+        assertTrue(predicate.test(null));
+        assertFalse(predicate.test("hello"));
+    }
+
+    @Test
+    void test_whenIsEqualIsInvokedWithNullInput_thenDoesNotMatch() throws Exception {
+        ThrowingPredicate<String> predicate = ThrowingPredicate.isEqual("hello");
+        assertFalse(predicate.test(null));
+    }
+}

--- a/src/test/java/org/zeplinko/commons/lang/ext/util/function/ThrowingRunnableTest.java
+++ b/src/test/java/org/zeplinko/commons/lang/ext/util/function/ThrowingRunnableTest.java
@@ -52,4 +52,43 @@ class ThrowingRunnableTest {
         };
         assertDoesNotThrow(runnable::run);
     }
+
+    @Test
+    void test_whenToUncheckedIsInvoked_thenReturnsStandardRunnable() {
+        AtomicInteger counter = new AtomicInteger(0);
+        ThrowingRunnable throwing = counter::incrementAndGet;
+        Runnable standard = throwing.toUnchecked();
+        standard.run();
+        assertEquals(1, counter.get());
+    }
+
+    @Test
+    void test_whenToUncheckedThrows_thenRethrowsAsRuntimeException() {
+        ThrowingRunnable throwing = () -> {
+            throw new IOException("io error");
+        };
+        Runnable standard = throwing.toUnchecked();
+        assertThrows(RuntimeException.class, standard::run);
+    }
+
+    @Test
+    void test_whenToUncheckedThrows_thenOriginalExceptionIsWrapped() {
+        IOException cause = new IOException("io error");
+        ThrowingRunnable throwing = () -> {
+            throw cause;
+        };
+        Runnable standard = throwing.toUnchecked();
+        RuntimeException ex = assertThrows(RuntimeException.class, standard::run);
+        assertSame(cause, ex.getCause());
+    }
+
+    @Test
+    void test_whenToUncheckedThrowsRuntimeException_thenNotWrapped() {
+        IllegalArgumentException original = new IllegalArgumentException("direct");
+        ThrowingRunnable throwing = () -> {
+            throw original;
+        };
+        RuntimeException ex = assertThrows(IllegalArgumentException.class, throwing.toUnchecked()::run);
+        assertSame(original, ex);
+    }
 }

--- a/src/test/java/org/zeplinko/commons/lang/ext/util/function/ThrowingSupplierTest.java
+++ b/src/test/java/org/zeplinko/commons/lang/ext/util/function/ThrowingSupplierTest.java
@@ -3,6 +3,7 @@ package org.zeplinko.commons.lang.ext.util.function;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -47,5 +48,42 @@ class ThrowingSupplierTest {
         String[] result = supplier.get();
         assertSame(expectedArray, result);
         assertArrayEquals(expectedArray, result);
+    }
+
+    @Test
+    void test_whenToUncheckedIsInvoked_thenReturnsStandardSupplier() {
+        ThrowingSupplier<String> throwing = () -> "hello";
+        Supplier<String> standard = throwing.toUnchecked();
+        assertEquals("hello", standard.get());
+    }
+
+    @Test
+    void test_whenToUncheckedThrows_thenRethrowsAsRuntimeException() {
+        ThrowingSupplier<String> throwing = () -> {
+            throw new IOException("io error");
+        };
+        Supplier<String> standard = throwing.toUnchecked();
+        assertThrows(RuntimeException.class, standard::get);
+    }
+
+    @Test
+    void test_whenToUncheckedThrows_thenOriginalExceptionIsWrapped() {
+        IOException cause = new IOException("io error");
+        ThrowingSupplier<String> throwing = () -> {
+            throw cause;
+        };
+        Supplier<String> standard = throwing.toUnchecked();
+        RuntimeException ex = assertThrows(RuntimeException.class, standard::get);
+        assertSame(cause, ex.getCause());
+    }
+
+    @Test
+    void test_whenToUncheckedThrowsRuntimeException_thenNotWrapped() {
+        IllegalArgumentException original = new IllegalArgumentException("direct");
+        ThrowingSupplier<String> throwing = () -> {
+            throw original;
+        };
+        RuntimeException ex = assertThrows(IllegalArgumentException.class, throwing.toUnchecked()::get);
+        assertSame(original, ex);
     }
 }


### PR DESCRIPTION
## Summary

  Enhances all **Throwing functional interfaces** with composition support, JDK interop, and introduces a new `ThrowingPredicate<T>` interface.

## Changes

  `ThrowingFunction<T, R>`
  - `andThen(ThrowingFunction)` — compose two functions in sequence
  - `compose(ThrowingFunction)` — compose with a before-function
  - `toUnchecked()` — adapt to standard Function for use in streams
  - `identity()` — static factory returning an identity function

  `ThrowingBiFunction<T, U, R>`
  - `andThen(ThrowingFunction)` — post-map the result
  - `toUnchecked()` — adapt to standard BiFunction

  `ThrowingConsumer<T> / ThrowingBiConsumer<T, U>`
  - `andThen(...)` — chain two consumers in sequence
  - `toUnchecked()` — adapt to standard Consumer / BiConsumer

  `ThrowingRunnable / ThrowingSupplier<T>`
  - `toUnchecked()` — adapt to standard Runnable / Supplier

  New: `ThrowingPredicate<T>`
  - `and, or, negate` — boolean composition with short-circuit evaluation
  - `isEqual(Object)` — static null-safe equality predicate
  - `not(ThrowingPredicate)` — static negation factory (mirrors JDK 11 Predicate.not)
  - `toUnchecked()` — adapt to standard Predicate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added composition methods to throwing functional interfaces for building function chains
  * Introduced `toUnchecked()` conversion method to adapt throwing functions to standard Java functional interfaces
  * Created new `ThrowingPredicate` interface with logical combinators (and, or, negate)
  * Added utility methods including `identity()` and `isEqual()`

* **Tests**
  * Comprehensive test coverage for composition, conversion, and exception handling behaviors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->